### PR TITLE
fix: ChannelRegistry implement and bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ SRCS := \
 	srcs/Command.cpp \
 	srcs/Server.cpp \
 	srcs/Session.cpp \
+	srcs/SessionRegistry.cpp \
 	srcs/utils.cpp \
 
 

--- a/includes/ChannelRegistry.hpp
+++ b/includes/ChannelRegistry.hpp
@@ -9,6 +9,8 @@
 
 class ChannelRegistry : public IChannelRegistry {
  public:
+  ChannelRegistry();
+  virtual ~ChannelRegistry();
   IRC::Numeric joinChannel(const std::string& channelName,
                            const std::string& nick,
                            IClientRegistry& clientRegistry,

--- a/srcs/ChannelRegistry.cpp
+++ b/srcs/ChannelRegistry.cpp
@@ -4,14 +4,26 @@
 
 #include "Channel.hpp"
 
+ChannelRegistry::ChannelRegistry() {}
+
+ChannelRegistry::~ChannelRegistry() {
+  for (std::map<std::string, IChannel*>::iterator it = channels.begin();
+       it != channels.end(); ++it) {
+    delete it->second;
+  }
+  channels.clear();
+}
+
 IRC::Numeric ChannelRegistry::joinChannel(const std::string& channelName,
                                           const std::string& nick,
                                           IClientRegistry& clientRegistry,
                                           const std::string& key) {
   std::map<std::string, IChannel*>::iterator iter = channels.find(channelName);
   if (iter == channels.end()) {
-    channels.insert(
-        std::make_pair(channelName, new Channel(channelName, clientRegistry)));
+    std::pair<std::map<std::string, IChannel*>::iterator, bool> result =
+        channels.insert(
+            std::make_pair(channelName, new Channel(channelName, clientRegistry)));
+    iter = result.first;
   }
 
   return iter->second->addClient(nick, key);


### PR DESCRIPTION
Fixed ChannelRegistry
- Added constructor and destructor declarations with proper memory cleanup
- fixed joinChannel() bug - Iterator was not updated after inserting a new channel, causing access to invalid memory

Added SessionRegistry.cpp to makefile

Compile and Server run tested successfully